### PR TITLE
feat: add pre-meeting announcement blog post and new `公告`, `會議`, `NPU…

### DIFF
--- a/blog/2025-12-16-pre-meeting-announcement.md
+++ b/blog/2025-12-16-pre-meeting-announcement.md
@@ -1,0 +1,36 @@
+---
+slug: 20251216-pre-meeting-announcement
+title: 資安戰隊及 NPU-EGO 會前會通知
+authors: [augchao]
+tags: [公告, 會議, NPU-EGO]
+---
+
+今天資安戰隊及 NPU-EGO 會前會，預計要討論以下議題：
+
+<!-- truncate -->
+
+## 會議議程
+
+### 1. PicoCTF 3 題
+討論 PicoCTF 競賽平台的題目。
+
+- [file-run1](https://play.picoctf.org/practice/challenge/266?category=3&difficulty=2&originalEvent=70&page=1&search=)
+- [file-run2](https://play.picoctf.org/practice/challenge/267?category=3&difficulty=2&originalEvent=70&page=1&search=)
+- [bloat.py](https://play.picoctf.org/practice/challenge/256?category=3&difficulty=2&originalEvent=70&page=1&search=)
+
+### 2. NPU-EGO 社團會前會
+- **社團章程**：審閱與確認社團組織章程
+- **社團成立大會**：籌備成立大會相關事宜
+- **其它討論**：其他社團運作相關議題
+
+### 3. 資安議題
+討論近期資安相關議題與訓練方向。
+
+---
+
+## 會議資訊
+
+- **時間**：今天 17:30
+- **地點**：多功能教室
+
+請各位準時出席，謝謝！

--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -17,3 +17,19 @@ hola:
   label: Hola
   permalink: /hola
   description: Hola tag description
+
+公告:
+  label: 公告
+  permalink: /announcement
+  description: 社團公告與通知
+
+會議:
+  label: 會議
+  permalink: /meeting
+  description: 會議相關資訊
+
+NPU-EGO:
+  label: NPU-EGO
+  permalink: /npu-ego
+  description: NPU-EGO 社團相關
+


### PR DESCRIPTION
This pull request adds a new pre-meeting announcement blog post and introduces several new tags for better content categorization. The main changes are the creation of a meeting announcement post and the expansion of tag definitions for announcements, meetings, and the NPU-EGO club.

**Content additions:**

* Added a new blog post, `2025-12-16-pre-meeting-announcement.md`, announcing a pre-meeting for the cybersecurity team and NPU-EGO, including the meeting agenda and logistical details.

**Tag and metadata improvements:**

* Updated `blog/tags.yml` to add new tags: `公告`, `會議`, and `NPU-EGO`, each with appropriate labels, permalinks, and descriptions for improved content organization and discoverability.…-EGO` tags